### PR TITLE
LSU 2025-03: corrections, suggestions

### DIFF
--- a/monthly-updates/2025-03.md
+++ b/monthly-updates/2025-03.md
@@ -30,13 +30,13 @@ The iwx driver for Intel WiFi chipsets originates from OpenBSD and was ported to
 
 iwx offers support for many recent Intel WiFi cards. This driver should support running these cards with legacy, HT and VHT rates. There are some issues remaining in the port, but at this point wider testing is sought.
 
-NOTE: To avoid breaking deployed WiFi configurations iwx probes with a lower priority than iwlwifi. This can be changed by blocking iwlwifi with devmatch.
+NOTE: To avoid breaking deployed WiFi configurations, iwx probes with a lower priority than iwlwifi. This can be changed by blocking `if_iwlwifi` with devmatch.
 
 GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/5
 
 ### pkgbasify tool is now more robust
 
-The pkgbasify tool was created to enable laptop users to transition their existing FreeBSD systems to pkgbase management. This month, updates have been released to improve reliability and user safety during the transition to managing the FreeBSD base system with pkgbase. 
+The pkgbasify tool was created to enable laptop users to transition their existing FreeBSD systems to pkgbase management. Updates improved reliability and user safety during the transition to managing the FreeBSD base system with pkgbase. 
 
 While the conversion process is inherently complex, this update significantly reduces risk by ensuring that no changes are made to the system if an error occurs before the critical point of no return — when pkgbasify begins overwriting base system files. Additionally, more error-prone steps, such as fetching required packages, are now performed early to prevent failures later in the process. 
 
@@ -44,11 +44,11 @@ To further support recovery in case of issues, pkgbasify will also attempt to cr
 
 GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/65
 
-## Work in review this month
+## Work in review
 
 ### Sleep using S0ix and s2idle low power states
 
-> This functionality remains in review from last month. 
+> This functionality remains in review from February. 
 
 A new power management driver (acpi_spmc) has been developed that can understand device power requirements and help laptops enter deeper sleep states using S0ix suspend hooks. This will enable better battery-saving sleep modes such as s2idle. Support for the lowest power state, D3cold, was added, along with fixes to ensure devices properly transition between power modes.
 
@@ -60,7 +60,7 @@ GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/32.
 
 ### Fixing blockers to make Linux WiFi drivers work
 
-> This functionality remains in review from last month, but there has been some progress with the review. Please see the GitHub issue for the latest updates. 
+> This functionality remains in review from February, but there has been some progress with the review. Please see the GitHub issue for the latest updates. 
 
 
 
@@ -75,7 +75,7 @@ GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/60
 
 ### Port of Linux 6.7 graphics drivers
 
-> This functionality remains in review from last month, but there has been some progress with the review. Please see the GitHub issue for the latest updates. 
+> This functionality remains in review from February, but there has been some progress with the review. Please see the GitHub issue for the latest updates. 
 
 The December [pull request to add support for Linux 6.7 graphics drivers to drm-kmod](https://github.com/freebsd/drm-kmod/pull/332) is now waiting for related patches to be accepted. Of 26 submitted patches, 24 have been accepted. There is also a [related hardware pull request](https://github.com/freebsd/drm-kmod-firmware/pull/36) that is open.
 
@@ -93,9 +93,9 @@ GitHub Issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/49
 
 #### Suspend and resume for LinuxKPI-based WiFi
 
-Work is  underway to ensure that LinuxKPI-controlled wireless adapters follow the laptop in suspend and resume transitions.
+Work is underway to ensure that LinuxKPI-controlled wireless adapters follow the laptop in suspend and resume transitions.
 
-In March, a general framework has been developed that successfully propagates suspend requests to the LinuxKPI management layer with only minor modifications required to the drivers.
+A general framework has been developed that successfully propagates suspend requests to the LinuxKPI management layer with only minor modifications required to the drivers.
 
 Currently, development is blocked by an issue in the LinuxKPI PCI code that needs to be resolved before work can continue. 
 
@@ -146,7 +146,7 @@ GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/17
 
 ## In conclusion
 
-The Foundation would to once again share a huge thank you to everyone involved with this project.
+The Foundation would like to once again share a huge thank you to everyone involved with this project.
 
 Thanks go out to:
 

--- a/monthly-updates/2025-03.md
+++ b/monthly-updates/2025-03.md
@@ -36,7 +36,7 @@ GitHub issue: https://github.com/FreeBSDFoundation/proj-laptop/issues/5
 
 ### pkgbasify tool is now more robust
 
-The pkgbasify tool was created to enable laptop users to transition their existing FreeBSD systems to pkgbase management. Updates improved reliability and user safety during the transition to managing the FreeBSD base system with pkgbase. 
+The pkgbasify tool was created to enable laptop users to transition their existing FreeBSD systems to pkgbase management. Updates have improved reliability and user safety during the conversion to managing the FreeBSD base system with pkgbase. 
 
 While the conversion process is inherently complex, this update significantly reduces risk by ensuring that no changes are made to the system if an error occurs before the critical point of no return — when pkgbasify begins overwriting base system files. Additionally, more error-prone steps, such as fetching required packages, are now performed early to prevent failures later in the process. 
 


### PR DESCRIPTION
if_iwlwifi, not iwlwifi, for devmatch_blocklist purposes.

Add a missing word (The Foundation would to …).

Whilst here: other minor suggestions.